### PR TITLE
Fix capv cluster credentials hook

### DIFF
--- a/charts/capi-vsphere/Chart.yaml
+++ b/charts/capi-vsphere/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - bootstrapping
 - kubernetes
 - vsphere
-version: 1.4.0
+version: 1.4.1
 appVersion: v1beta1
 home: https://cluster-api.sigs.k8s.io/
 sources:

--- a/charts/capi-vsphere/templates/cloud-secret.yaml
+++ b/charts/capi-vsphere/templates/cloud-secret.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "capi-vsphere.cloudConfigSecretName" . }}
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-failed
 data:
   username: {{ .Values.cloudConfigSecret.username | b64enc }}
   password: {{ .Values.cloudConfigSecret.password | b64enc }}


### PR DESCRIPTION
When deployed on argocd pre-install hook will be deleted and recreated on every sync. Thats how argo maps helm hooks to argocd waves.

Currently this secret get added a finalizer to prevent accidental deletion, so syncs in argo get stuck on secret delete action.

Add annotations to hook wich skip resource recreation on syncs.

Bump chart patch number