### PR TITLE
Fix field nodeStartupTimeout in machine-health-checks

### DIFF
--- a/charts/capi-vsphere/Chart.yaml
+++ b/charts/capi-vsphere/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - bootstrapping
 - kubernetes
 - vsphere
-version: 1.4.1
+version: 1.4.2
 appVersion: v1beta1
 home: https://cluster-api.sigs.k8s.io/
 sources:

--- a/charts/capi-vsphere/templates/machine-health-checks-management.yaml
+++ b/charts/capi-vsphere/templates/machine-health-checks-management.yaml
@@ -14,8 +14,8 @@ spec:
   remediationTemplate:
     {{- toYaml $md.remediationTemplate | nindent 4 }}
   {{- end }}
-  {{- with $md.nodeStartUpTimeout }}
-  nodeStartUpTimeout: {{ . }}
+  {{- with $md.nodeStartupTimeout }}
+  nodeStartupTimeout: {{ . }}
   {{- end }}
   selector:
   {{- with $md.selector.matchLabels }}


### PR DESCRIPTION
Installing the chart wit machine-healthcheck values gives the warning:

```bash
warnings.go:70] unknown field "spec.nodeStartUpTimeout"
```

k explain machinehealthchecks.cluster.x-k8s.io.spec shows that the field is called `nodeStartupTimeout` with a low caps u.