### PR TITLE
Fix template rendering

### DIFF
--- a/charts/capi-cloudstack/Chart.yaml
+++ b/charts/capi-cloudstack/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - bootstrapping 
 - kubernetes
 - cloudstack
-version: 0.1.0 
+version: 0.2.0
 home: https://cluster-api.sigs.k8s.io/ 
 sources:
 - https://cluster-api.sigs.k8s.io/

--- a/charts/capi-cloudstack/templates/cloudstack-machine-templates.yaml
+++ b/charts/capi-cloudstack/templates/cloudstack-machine-templates.yaml
@@ -14,7 +14,7 @@ spec:
       {{- end }}
       {{- if .Values.controlPlaneTemplate.details }}
       details: 
-        {{ toYaml .Values.controlPlaneTemplate.details }}
+        {{ toYaml .Values.controlPlaneTemplate.details | nindent 8 }}
       {{- end }}
 
 {{ range $index, $template := .Values.machineTemplates }}
@@ -29,6 +29,10 @@ spec:
     spec:
       template: 
         name: {{ required (printf "imageName is required for .Values.machineTemplates.%d" $index) $template.imageName }}
+      {{- if $template.diskOffering }}
+      diskOffering:
+        {{- $template.diskOffering | toYaml | nindent 8 }}
+      {{- end }}
       offering:
         name: {{ required (printf "offeringName is required for .Values.machineTemplates.%d" $index) $template.offeringName }}
       {{- if $template.sshKeyName }}
@@ -36,6 +40,6 @@ spec:
       {{- end }}
       {{- if $template.details }}
       details: 
-        {{ toYaml $template.details }}
+        {{- toYaml $template.details | nindent 8 }}
       {{- end }}
 {{ end }}

--- a/charts/capi-cloudstack/templates/machine-deployment.yaml
+++ b/charts/capi-cloudstack/templates/machine-deployment.yaml
@@ -40,12 +40,12 @@ spec:
       joinConfiguration:
       {{- toYaml (required ".Values.kubeadm.joinConfiguration"
         $.Values.kubeadm.joinConfiguration ) | nindent 8 }}
-      {{ if $.Values.kubeadm.preKubeadmCommands }}
-      preKubeadmCommands:
-      {{- toYaml $.Values.kubeadm.preKubeadmCommands | nindent 8 }}
-      {{ end -}}
       {{ if $.Values.kubeadm.files }}
       files:
       {{- toYaml $.Values.kubeadm.files | nindent 8 }}
       {{ end -}}
+      {{ if $.Values.kubeadm.preKubeadmCommands }}
+      preKubeadmCommands:
+      {{- toYaml $.Values.kubeadm.preKubeadmCommands | nindent 8 }}
+      {{ end }}
 {{ end }}


### PR DESCRIPTION
Add support for diskOffering setting on CloudstackMachineTemplate.

Fix rendering error on MachineDeployment template causing render error when multiple `machineDeployments` were created.

Fix rendering error on CloudstackMachineTemplate details section causing rendering error when several details were passed to `machineTemplates` definition.

Bump chart version to 0.2.0