### PR TITLE
update how KubeadmConfigTemplates are linked to machine deployments

### DIFF
--- a/charts/capi-cloudstack/Chart.yaml
+++ b/charts/capi-cloudstack/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - bootstrapping 
 - kubernetes
 - cloudstack
-version: 0.3.0
+version: 1.0.0
 home: https://cluster-api.sigs.k8s.io/ 
 sources:
 - https://cluster-api.sigs.k8s.io/

--- a/charts/capi-cloudstack/templates/machine-deployment.yaml
+++ b/charts/capi-cloudstack/templates/machine-deployment.yaml
@@ -1,5 +1,6 @@
 {{- range $index, $md := .Values.machineDeployments }}
 {{- $object := dict "MachineDeployment" $md "Index" $index "Context" $ -}}
+{{- $kadmconfig := merge (default dict $md.kubeadm) $.Values.kubeadm }}
 ---
 apiVersion: cluster.x-k8s.io/{{ $.Values.clusterapiVersion }}
 kind: MachineDeployment
@@ -34,18 +35,18 @@ metadata:
 spec:
   template:
     spec:
-      {{ if $.Values.kubeadm.users }}
-      users: {{ toYaml $.Values.kubeadm.users | nindent 8 }}
+      {{ if $kadmconfig.users }}
+      users: {{ toYaml $kadmconfig.users | nindent 8 }}
       {{ end }}
       joinConfiguration:
       {{- toYaml (required ".Values.kubeadm.joinConfiguration"
-        $.Values.kubeadm.joinConfiguration ) | nindent 8 }}
-      {{ if $.Values.kubeadm.files }}
+        $kadmconfig.joinConfiguration ) | nindent 8 }}
+      {{ if $kadmconfig.files }}
       files:
-      {{- toYaml $.Values.kubeadm.files | nindent 8 }}
+      {{- toYaml $kadmconfig.files | nindent 8 }}
       {{ end -}}
-      {{ if $.Values.kubeadm.preKubeadmCommands }}
+      {{ if $kadmconfig.preKubeadmCommands }}
       preKubeadmCommands:
-      {{- toYaml $.Values.kubeadm.preKubeadmCommands | nindent 8 }}
+      {{- toYaml $kadmconfig.preKubeadmCommands | nindent 8 }}
       {{ end }}
 {{ end }}

--- a/charts/capi-cloudstack/values.yaml
+++ b/charts/capi-cloudstack/values.yaml
@@ -92,6 +92,10 @@ machineTemplates: []
 #  - name: production
 #    templateName: prodTemplate
 #    replicas: 3
+#    kubeadm:
+#     preKubeadmCommands:
+#       - swapoff -a
+#       - sudo apt update
 #  - name: develop
 #    templateName: smallTemplate
 #    replicas: 2


### PR DESCRIPTION
Currently the key `kubeadm` holds configuration to kubadm for all
cluster machines. That implies that changing the kubeadm impacts in
**all** machine deployments (including control planes).

Add support to set custom kubeadmconfig per machine deployment; so, when
needed, custom configs can be applied to each machinedeployment
independently