### PR TITLE
fix: capi-vsphere compatibility with Kubernetes >= 1.29

### DIFF
--- a/charts/capi-openstack/Chart.yaml
+++ b/charts/capi-openstack/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - bootstrapping 
 - kubernetes
 - openstack
-version: 1.2.0
+version: 1.2.1
 home: https://cluster-api.sigs.k8s.io/ 
 sources:
 - https://cluster-api.sigs.k8s.io/

--- a/charts/capi-openstack/values.yaml
+++ b/charts/capi-openstack/values.yaml
@@ -105,7 +105,7 @@ kubeadm:
     controllerManager:
       extraArgs:
         cloud-provider: external
-    imageRepository: k8s.gcr.io
+    imageRepository: registry.k8s.io
   initConfiguration:
     nodeRegistration:
       kubeletExtraArgs:

--- a/charts/capi-vsphere/Chart.yaml
+++ b/charts/capi-vsphere/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - bootstrapping
 - kubernetes
 - vsphere
-version: 1.6.0
+version: 1.7.0
 appVersion: v1beta1
 home: https://cluster-api.sigs.k8s.io/
 sources:

--- a/charts/capi-vsphere/templates/kubeadm-control-plane.yaml
+++ b/charts/capi-vsphere/templates/kubeadm-control-plane.yaml
@@ -77,6 +77,53 @@ spec:
           status: {}
         owner: root:root
         path: /etc/kubernetes/manifests/kube-vip.yaml
+      - content: |
+          #!/bin/bash
+
+          # Copyright 2020 The Kubernetes Authors.
+          #
+          # Licensed under the Apache License, Version 2.0 (the "License");
+          # you may not use this file except in compliance with the License.
+          # You may obtain a copy of the License at
+          #
+          #     http://www.apache.org/licenses/LICENSE-2.0
+          #
+          # Unless required by applicable law or agreed to in writing, software
+          # distributed under the License is distributed on an "AS IS" BASIS,
+          # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+          # See the License for the specific language governing permissions and
+          # limitations under the License.
+
+          set -e
+
+          # Configure the workaround required for kubeadm init with kube-vip:
+          # xref: https://github.com/kube-vip/kube-vip/issues/684
+
+          # Nothing to do for kubernetes < v1.29
+          KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
+          if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
+            exit 0
+          fi
+
+          IS_KUBEADM_INIT="false"
+
+          # cloud-init kubeadm init
+          if [[ -f /run/kubeadm/kubeadm.yaml ]]; then
+            IS_KUBEADM_INIT="true"
+          fi
+
+          # ignition kubeadm init
+          if [[ -f /etc/kubeadm.sh ]] && grep -q -e "kubeadm init" /etc/kubeadm.sh; then
+            IS_KUBEADM_INIT="true"
+          fi
+
+          if [[ "$IS_KUBEADM_INIT" == "true" ]]; then
+            sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' \
+              /etc/kubernetes/manifests/kube-vip.yaml
+          fi
+        owner: root:root
+        path: /etc/kube-vip-prepare.sh
+        permissions: "0700"
         {{- end }}
         {{- with .Values.kubeadm.files }}
         {{ toYaml . | nindent 6 }}

--- a/charts/capi-vsphere/values.yaml
+++ b/charts/capi-vsphere/values.yaml
@@ -148,7 +148,6 @@ kubeadm:
   version: v1.20.9
   # must use one of the defined in controlPlaneTemplates
   templateName: ""
-  preKubeadmCommands: []
   users: []
   ntp: {}
   files: []
@@ -159,7 +158,7 @@ kubeadm:
     controllerManager:
       extraArgs:
         cloud-provider: external
-    imageRepository: k8s.gcr.io
+    imageRepository: registry.k8s.io
   useExperimentalRetryJoin: true
   preKubeadmCommands:
     - hostname "{{ ds.meta_data.hostname }}"
@@ -167,6 +166,7 @@ kubeadm:
     - echo "127.0.0.1   localhost" >>/etc/hosts
     - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
     - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    - /etc/kube-vip-prepare.sh
   initConfiguration:
     nodeRegistration:
       criSocket: /var/run/containerd/containerd.sock


### PR DESCRIPTION
## Summary

- **capi-vsphere** (1.6.0 → 1.7.0):
  - Replace deprecated `k8s.gcr.io` with `registry.k8s.io` (gcr.io shut down April 2023)
  - Add `kube-vip-prepare.sh` script to handle `super-admin.conf` requirement introduced in K8s 1.29 ([kube-vip/kube-vip#684](https://github.com/kube-vip/kube-vip/issues/684)). Script checks K8s version and distinguishes `kubeadm init` from `kubeadm join`, so HA clusters with multiple control plane nodes continue to work correctly. Same approach already used by capi-proxmox.

- **capi-openstack** (1.2.0 → 1.2.1):
  - Replace deprecated `k8s.gcr.io` with `registry.k8s.io`

- **capi-proxmox**, **capi-cloudstack**: no changes (already had correct registry and kube-vip handling)

## Notes

- OpenStack and CloudStack don't use kube-vip — they rely on their native load balancers (Octavia for OpenStack, built-in LB for CloudStack)
- The kube-vip script drops support for K8s <= 1.28, which reached EOL in October 2024